### PR TITLE
VCB-23-Runtime Errors

### DIFF
--- a/src/board/processor.ts
+++ b/src/board/processor.ts
@@ -105,6 +105,7 @@ export class Processor extends EventEmitter<ProcessorEvents> {
   }
 
   private cycle() {
+    let pcIncremented = false
     let executor: IInstructionExecutor | undefined = undefined
 
     try {
@@ -123,6 +124,7 @@ export class Processor extends EventEmitter<ProcessorEvents> {
         Register.PC,
         pc.add(executor.opcodeLength * 2)
       )
+      pcIncremented = true
       executor.executeInstruction(opcode, this.registers, this.memory)
       this.emit('afterCycle')
     } catch (e: any) {
@@ -131,7 +133,7 @@ export class Processor extends EventEmitter<ProcessorEvents> {
 
         // in case error happened during execution of the instruction, the program counter has to be set back
         // so the correct address is fetched from the source map to highlight the line
-        if (executor) {
+        if (executor && pcIncremented) {
           const pc = this.registers.readRegister(Register.PC)
           this.registers.writeRegister(
             Register.PC,


### PR DESCRIPTION
The processor now catches all possible types of error during execution and fires a `runtimeError` event that is handled by the code editor.

When the editor receives the `runtimeError` event:
* All highlighting is cleared.
* The current program counter value is highlighted with the error color in the editor. The processor will check if the program counter was already increased and decreases the program counter in case an exception happens. Otherwise if the exception happens within the `onExecuteInstruction()` method in the `IInstructionExecutor` type the wrong line would be highlighted because at this time the program counter was already increased. Maybe there are better solutions for this, here I'm open to suggestions.
* The error is shown in the error box as usual and the editor is set back to the `EDIT` mode but the processor state is not reset so that the user can check things. This change requires now to always reset the processor before running the code, so essentially every time the processor changes from mode `EDIT` to mode `RUN` or `STEP` the processor will now additionally be reset although this would only be necessary if a runtime exception occurred previously.