### PR TITLE
VCB-186 Fix: allow multiple labels on DCD instruction

### DIFF
--- a/src/assembler/encoder.ts
+++ b/src/assembler/encoder.ts
@@ -209,8 +209,7 @@ function isDataInstruction(instruction: IInstruction): boolean {
 function isSymbolDataInstruction(instruction: IInstruction): boolean {
   return (
     instruction.name == 'DCD' &&
-    instruction.options.length == 1 &&
-    isNaN(+instruction.options[0])
+    instruction.options.every((option) => isNaN(+option))
   )
 }
 
@@ -226,8 +225,10 @@ function writeDataInstruction(
 ): void {
   if (isSymbolDataInstruction(instruction)) {
     const bytes = Word.fromUnsignedInteger(0x0).toBytes()
-    writer.addDataRelocation(instruction.options[0], bytes.length)
-    writer.writeBytes(bytes, 4)
+    for (const option of instruction.options) {
+      writer.addDataRelocation(option, bytes.length)
+      writer.writeBytes(bytes, 4)
+    }
     return
   } else if (instruction.name === 'ALIGN') {
     const alignment =

--- a/test/assembler/encoder.test.ts
+++ b/test/assembler/encoder.test.ts
@@ -117,6 +117,50 @@ describe('encode', function () {
     expect(file.content[6].value).toBe(0x00)
     expect(file.content[7].value).toBe(0x00)
   })
+  it('should encode DCD instruction with labels', function () {
+    const code: ICodeFile = {
+      symbols: {},
+      areas: [
+        {
+          type: AreaType.Data,
+          isReadOnly: true,
+          name: '|.data|',
+          instructions: [
+            {
+              name: 'DCD',
+              options: ['case1', 'case2'],
+              line: 0
+            }
+          ]
+        }
+      ]
+    }
+    const file = encode(code)
+    expect(Object.keys(file.sections).length).toBe(1)
+    expect(getSection(file, '|.data|').offset).toBe(0)
+    expect(getSection(file, '|.data|').size).toBe(8)
+    expect(file.content.length).toBe(8)
+    expect(file.content[0].value).toBe(0x00)
+    expect(file.content[1].value).toBe(0x00)
+    expect(file.content[2].value).toBe(0x00)
+    expect(file.content[3].value).toBe(0x00)
+    expect(file.content[4].value).toBe(0x00)
+    expect(file.content[5].value).toBe(0x00)
+    expect(file.content[6].value).toBe(0x00)
+    expect(file.content[7].value).toBe(0x00)
+
+    expect(file.relocations.length).toBe(2)
+    expect(file.relocations[0].type).toBe(RelocationType.Data)
+    expect(file.relocations[0].section).toBe('|.data|')
+    expect(file.relocations[0].offset).toBe(0)
+    expect(file.relocations[0].length).toBe(4)
+    expect(file.relocations[0].symbol).toBe('case1')
+    expect(file.relocations[1].type).toBe(RelocationType.Data)
+    expect(file.relocations[1].section).toBe('|.data|')
+    expect(file.relocations[1].offset).toBe(4)
+    expect(file.relocations[1].length).toBe(4)
+    expect(file.relocations[1].symbol).toBe('case2')
+  })
   it('should encode SPACE instruction', function () {
     for (const name of ['SPACE', 'FILL', '%']) {
       const code: ICodeFile = {


### PR DESCRIPTION
Test Code

```
AREA |.data|, DATA, READWRITE
                    

ADDR_LED_15_0           EQU     0x60000100
ADDR_LED_31_16          EQU     0x60000102
ADDR_7_SEG_BIN_DS1_0    EQU     0x60000114
ADDR_DIP_SWITCH_15_0    EQU     0x60000200
ADDR_HEX_SWITCH         EQU     0x60000211

NR_CASES        		EQU     0xB
BIT_MASK				EQU		0xFFF0

jump_table
						DCD   case_dark, case_add, case_minus
					
    
AREA |.text|, CODE, READONLY
; -------------------------------------------------------------------
; -- Main
; -------------------------------------------------------------------   
                        
MOVS R0, #1
MOVS R1, #1
MOVS R2, #1
LSLS  	R2, #2  
LDR   	R7, =jump_table 
LDR   	R7, [R7, R2] 
BX    	R7

; STUDENTS: To be programmed

case_dark       
                LDR  	R0, =0

case_add        
                ADDS 	R0, R0, R1
case_minus        
                ADDS 	R0, R0, R1

```