### PR TITLE
VCB-189 Fix: enable the use of EQU constant for immediate values like in MOVS or CMP etc.

### DIFF
--- a/src/assembler/encoder.ts
+++ b/src/assembler/encoder.ts
@@ -86,6 +86,12 @@ export function encode(code: ICodeFile): IELF {
   return file
 }
 
+/**
+ * Creates a map for fast lookup of equ constants.
+ *
+ * @param file file from which the map is created
+ * @returns created map
+ */
 function createEquConstantsMap(file: IELF): Map<string, Word> {
   const equConstants: Map<string, Word> = new Map<string, Word>()
   for (const symbol in file.symbols) {
@@ -95,6 +101,12 @@ function createEquConstantsMap(file: IELF): Map<string, Word> {
   return equConstants
 }
 
+/**
+ * Replaces all references to equ constants for the given instruction with the actual value.
+ *
+ * @param instruction instruction to replace options
+ * @param equConstants map of equ constant that is used to lookup the actual value
+ */
 function replaceEquConstants(
   instruction: IInstruction,
   equConstants: Map<string, Word>

--- a/src/assembler/encoder.ts
+++ b/src/assembler/encoder.ts
@@ -61,6 +61,7 @@ export function encode(code: ICodeFile): IELF {
   const file = createFile()
   const writer = new FileWriter(file)
   addSymbols(writer, code.symbols)
+  const equConstants: Map<string, Word> = createEquConstantsMap(file)
   for (const area of code.areas) {
     const type = $enum(SectionType).asValueOrThrow(area.type)
     writer.startSection(type, area.name)
@@ -68,6 +69,7 @@ export function encode(code: ICodeFile): IELF {
     for (const instruction of area.instructions) {
       writer.mapLine(instruction.line)
       addLabel(writer, instruction)
+      replaceEquConstants(instruction, equConstants)
       try {
         writeInstruction(writer, instruction, pool)
       } catch (e: any) {
@@ -82,6 +84,37 @@ export function encode(code: ICodeFile): IELF {
     writer.endSection()
   }
   return file
+}
+
+function createEquConstantsMap(file: IELF): Map<string, Word> {
+  const equConstants: Map<string, Word> = new Map<string, Word>()
+  for (const symbol in file.symbols) {
+    if (file.symbols[symbol].type === SymbolType.Constant)
+      equConstants.set(file.symbols[symbol].name, file.symbols[symbol].value)
+  }
+  return equConstants
+}
+
+function replaceEquConstants(
+  instruction: IInstruction,
+  equConstants: Map<string, Word>
+): void {
+  for (let i = 0; i < instruction.options.length; i++) {
+    if (
+      instruction.options[i].startsWith('#') &&
+      isNaN(+instruction.options[i].slice(1))
+    ) {
+      const val = equConstants.get(instruction.options[i].slice(1))
+      if (val) {
+        instruction.options[i] = '#' + val.toUnsignedInteger().toString()
+      } else {
+        throw new AssemblerError(
+          `Instruction refers to constant ${instruction.options[i]} which does not exists.`,
+          instruction.line
+        )
+      }
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Code to test:
```
AREA myCode, CODE, READONLY
NR_CASES EQU 0xB
ALL_BRIGHT EQU 0xFFFF
CMP R2, #NR_CASES
```

* Error should be thrown if instruction references equ constant that does not exist.