### PR TITLE
VCB-144 Stack instructions

### DIFF
--- a/src/assembler/parser/index.ts
+++ b/src/assembler/parser/index.ts
@@ -6,7 +6,7 @@ const SYMBOL = `[a-z_]+[a-z0-9_]*|\\|[a-z0-9._ ]+\\|`
 const VALUE = `[0-9a-z#]+`
 const SPACE_OR_TAB = `[ \\t]`
 
-const OPTION = `[0-9a-z#\\[\\]=_{}]+`
+const OPTION = `[0-9a-z#\\[\\]=_{}-]+`
 const INSTRUCTION = `([a-z]+)${SPACE_OR_TAB}+(${OPTION}(${SPACE_OR_TAB}*,${SPACE_OR_TAB}*${OPTION})*)`
 const COMMENT = `;[^\\n]*`
 

--- a/src/assembler/parser/index.ts
+++ b/src/assembler/parser/index.ts
@@ -6,7 +6,7 @@ const SYMBOL = `[a-z_]+[a-z0-9_]*|\\|[a-z0-9._ ]+\\|`
 const VALUE = `[0-9a-z#]+`
 const SPACE_OR_TAB = `[ \\t]`
 
-const OPTION = `[0-9a-z#\\[\\]=_{}-]+`
+const OPTION = `(?:[0-9a-z#=_]|[\\[{]${SPACE_OR_TAB}*|${SPACE_OR_TAB}*[\\]}]|${SPACE_OR_TAB}*-${SPACE_OR_TAB}*)+`
 const INSTRUCTION = `([a-z]+)${SPACE_OR_TAB}+(${OPTION}(${SPACE_OR_TAB}*,${SPACE_OR_TAB}*${OPTION})*)`
 const COMMENT = `;[^\\n]*`
 

--- a/src/components/editor/assembly.grammar
+++ b/src/components/editor/assembly.grammar
@@ -46,7 +46,7 @@ MachineInstruction {
 }
 
 PushPopInstruction {
-  (kw<"PUSH"> | kw<"POP">) "{" commaSep<RegisterLiteral> "}"
+  (kw<"PUSH"> | kw<"POP">) "{" commaSep<RegisterLiteral | RegisterLiteralRange> "}"
 }
 
 BranchInstruction {
@@ -152,6 +152,8 @@ kw<term> { @specialize[@name="Keyword"]<identifier, term> }
   identifier { $[A-Za-z0-9_]+ }
 
   RegisterLiteral { "R" $[0-9] | "R1" $[1-2] | "SP" | "LR" | "PC" }
+
+  RegisterLiteralRange { RegisterLiteral "-" RegisterLiteral }
 
   digits {
     $[0-9]+

--- a/src/components/editor/assembly.grammar
+++ b/src/components/editor/assembly.grammar
@@ -153,7 +153,7 @@ kw<term> { @specialize[@name="Keyword"]<identifier, term> }
 
   RegisterLiteral { "R" $[0-9] | "R1" $[1-2] | "SP" | "LR" | "PC" }
 
-  RegisterLiteralRange { RegisterLiteral "-" RegisterLiteral }
+  RegisterLiteralRange { RegisterLiteral space* "-" space* RegisterLiteral }
 
   digits {
     $[0-9]+

--- a/src/components/editor/assembly.ts
+++ b/src/components/editor/assembly.ts
@@ -11,6 +11,7 @@ export const AssemblyLanguage = LRLanguage.define({
         CodeOrDataArea: t.variableName,
         VariableName: t.variableName,
         RegisterLiteral: t.variableName,
+        RegisterLiteralRange: t.variableName,
         IntegerLiteral: t.number,
         MachInstrIntegerLiteral: t.number,
         MachInstrSymbolicLiteral: t.variableName,

--- a/src/instruction/instructions/stack/pop.ts
+++ b/src/instruction/instructions/stack/pop.ts
@@ -9,8 +9,6 @@ export class PopInstruction extends StackInstruction {
   public pattern: string = '1011110XXXXXXXXX'
   protected additionalRegister: Register = Register.PC
 
-  private pcRegisterPosition = 8
-
   public encodeInstruction(options: string[]): Halfword[] {
     checkOptionCount(options, 1, 9)
     this.checkCurlyBracketsOnOptions(options)
@@ -30,7 +28,7 @@ export class PopInstruction extends StackInstruction {
       .add(4 * registerValues.length)
     registers.writeRegister(Register.SP, address)
     for (const registerVal of registerValues) {
-      memory.writeWord(address, registers.readRegister(registerVal))
+      registers.writeRegister(registerVal, memory.readWord(address))
       address = address.add(-4)
     }
   }

--- a/src/instruction/instructions/stack/pop.ts
+++ b/src/instruction/instructions/stack/pop.ts
@@ -23,13 +23,11 @@ export class PopInstruction extends StackInstruction {
     memory: IMemory
   ) {
     let registerValues = this.getStackRegisterFromOpcode(opcode[0])
-    let address = registers
-      .readRegister(Register.SP)
-      .add(4 * registerValues.length)
-    registers.writeRegister(Register.SP, address)
+    let address = registers.readRegister(Register.SP)
     for (const registerVal of registerValues) {
       registers.writeRegister(registerVal, memory.readWord(address))
-      address = address.add(-4)
+      address = address.add(4)
     }
+    registers.writeRegister(Register.SP, address)
   }
 }

--- a/src/instruction/instructions/stack/pop.ts
+++ b/src/instruction/instructions/stack/pop.ts
@@ -4,10 +4,12 @@ import { checkOptionCount, create } from 'instruction/opcode'
 import { Halfword } from 'types/binary'
 import { StackInstruction } from './util'
 
-export class PushInstruction extends StackInstruction {
-  public name: string = 'PUSH'
-  public pattern: string = '1011010XXXXXXXXX'
-  protected additionalRegister: Register = Register.LR
+export class PopInstruction extends StackInstruction {
+  public name: string = 'POP'
+  public pattern: string = '1011110XXXXXXXXX'
+  protected additionalRegister: Register = Register.PC
+
+  private pcRegisterPosition = 8
 
   public encodeInstruction(options: string[]): Halfword[] {
     checkOptionCount(options, 1, 9)
@@ -23,14 +25,13 @@ export class PushInstruction extends StackInstruction {
     memory: IMemory
   ) {
     let registerValues = this.getStackRegisterFromOpcode(opcode[0])
-
     let address = registers
       .readRegister(Register.SP)
-      .add(-4 * registerValues.length)
+      .add(4 * registerValues.length)
     registers.writeRegister(Register.SP, address)
     for (const registerVal of registerValues) {
       memory.writeWord(address, registers.readRegister(registerVal))
-      address = address.add(4)
+      address = address.add(-4)
     }
   }
 }

--- a/src/instruction/instructions/stack/push.ts
+++ b/src/instruction/instructions/stack/push.ts
@@ -1,0 +1,95 @@
+import { IMemory } from 'board/memory/interfaces'
+import { Register, Registers } from 'board/registers'
+import { InstructionError } from 'instruction/error'
+import { BaseInstruction } from 'instruction/instructions/base'
+import {
+  checkOptionCount,
+  create,
+  getBits,
+  getEnumValueForRegisterString
+} from 'instruction/opcode'
+import { Halfword } from 'types/binary'
+
+export class PushInstruction extends BaseInstruction {
+  public name: string = 'PUSH'
+  public pattern: string = '1011010XXXXXXXXX'
+
+  private lrRegisterPosition = 8
+
+  public encodeInstruction(options: string[]): Halfword[] {
+    checkOptionCount(options, 1, 9)
+    let opcode: Halfword = create(this.pattern)
+    const registers = this.getRegisters(options)
+
+    for (const register of registers) {
+      if (Registers.isLowRegister(register)) {
+        opcode = opcode.setBit(register)
+      } else if (register === Register.LR) {
+        opcode = opcode.setBit(this.lrRegisterPosition)
+      }
+    }
+
+    return [opcode]
+  }
+
+  protected onExecuteInstruction(
+    opcode: Halfword[],
+    registers: Registers,
+    memory: IMemory
+  ) {
+    const registerList = getBits(opcode[0], this.pattern)
+    const registerValues: Register[] = []
+    let bitCount = 0
+    for (let i = 0; i <= this.lrRegisterPosition; i++) {
+      if (registerList.isBitSet(i)) {
+        bitCount++
+        registerValues.push(i)
+      }
+    }
+
+    let address = registers.readRegister(Register.SP).add(-4 * bitCount)
+    registers.writeRegister(Register.SP, address)
+    for (const register of registerValues) {
+      memory.writeWord(address, registers.readRegister(register))
+      address = address.add(4)
+    }
+  }
+
+  private getRegisters(options: string[]): Register[] {
+    const registers: Register[] = []
+    for (const option of options) {
+      let value = option.replace('{', '')
+      value = value.replace('}', '')
+      if (value.includes('-')) {
+        const values = value.split('-')
+        const start = this.getRegister(values[0])
+        const end = this.getRegister(values[1])
+        registers.push(...this.getRegisterRange(start, end))
+      } else {
+        registers.push(this.getRegister(value))
+      }
+    }
+
+    return registers
+  }
+
+  private getRegisterRange(start: Register, end: Register): Register[] {
+    const registers: Register[] = []
+    for (let i = start; i <= end; i++) {
+      registers.push(i)
+    }
+
+    return registers
+  }
+
+  private getRegister(value: string): Register {
+    const register = getEnumValueForRegisterString(value)
+    if (!Registers.isLowRegister(register) && register !== Register.LR) {
+      throw new InstructionError(
+        'Provided register is not a low register or the LR register.'
+      )
+    }
+
+    return register
+  }
+}

--- a/src/instruction/instructions/stack/util.ts
+++ b/src/instruction/instructions/stack/util.ts
@@ -32,15 +32,15 @@ export abstract class StackInstruction extends BaseInstruction {
   protected getStackRegisterFromOpcode(opcode: Halfword): Register[] {
     const registerList = getBits(opcode, this.registerBitsPattern)
     const registerValues: Register[] = []
-    for (let i = 0; i <= this.lrOrPcRegisterPosition; i++) {
+    for (let i = 0; i < this.lrOrPcRegisterPosition; i++) {
       if (registerList.isBitSet(i)) {
-        if (i === this.lrOrPcRegisterPosition) {
-          registerValues.push(this.additionalRegister)
-        } else {
-          registerValues.push(i)
-        }
+        registerValues.push(i)
       }
     }
+    if (registerList.isBitSet(this.lrOrPcRegisterPosition)) {
+      registerValues.push(this.additionalRegister)
+    }
+
     return registerValues
   }
 

--- a/src/instruction/instructions/stack/util.ts
+++ b/src/instruction/instructions/stack/util.ts
@@ -1,6 +1,7 @@
 import { Register, Registers } from 'board/registers'
 import { InstructionError } from 'instruction/error'
 import { getBits, getEnumValueForRegisterString } from 'instruction/opcode'
+import { $enum } from 'ts-enum-util'
 import { Halfword } from 'types/binary'
 import { BaseInstruction } from '../base'
 
@@ -26,7 +27,7 @@ export abstract class StackInstruction extends BaseInstruction {
       }
     }
 
-    return Halfword.fromUnsignedInteger(0)
+    return opcode
   }
   protected getStackRegisterFromOpcode(opcode: Halfword): Register[] {
     const registerList = getBits(opcode, this.registerBitsPattern)
@@ -40,7 +41,7 @@ export abstract class StackInstruction extends BaseInstruction {
   }
 
   private correctLrOrPcRegisterProvided(register: Register): boolean {
-    return register !== this.additionalRegister
+    return register === this.additionalRegister
   }
 
   private getRegisters(options: string[]): Register[] {
@@ -93,7 +94,9 @@ export abstract class StackInstruction extends BaseInstruction {
       !this.correctLrOrPcRegisterProvided(register)
     ) {
       throw new InstructionError(
-        'Provided register is not a low register or the LR register.'
+        `Provided register is not a low register or the ${$enum(
+          Register
+        ).getKeyOrThrow(this.additionalRegister)} register.`
       )
     }
     return register
@@ -111,13 +114,11 @@ export abstract class StackInstruction extends BaseInstruction {
         throw new InstructionError(
           `Opening or closing curly bracket missing for 1. param.`
         )
+      } else {
+        throw new InstructionError(
+          `Opening curly bracket on 1. param or closing bracket on ${options.length}. param missing.`
+        )
       }
-    } else {
-      throw new InstructionError(
-        `Opening curly bracket on 1. param or closing bracket on ${
-          options.length - 1
-        }. param missing.`
-      )
     }
   }
 

--- a/src/instruction/instructions/stack/util.ts
+++ b/src/instruction/instructions/stack/util.ts
@@ -34,7 +34,11 @@ export abstract class StackInstruction extends BaseInstruction {
     const registerValues: Register[] = []
     for (let i = 0; i <= this.lrOrPcRegisterPosition; i++) {
       if (registerList.isBitSet(i)) {
-        registerValues.push(i)
+        if (i === this.lrOrPcRegisterPosition) {
+          registerValues.push(this.additionalRegister)
+        } else {
+          registerValues.push(i)
+        }
       }
     }
     return registerValues

--- a/src/instruction/instructions/stack/util.ts
+++ b/src/instruction/instructions/stack/util.ts
@@ -1,0 +1,136 @@
+import { Register, Registers } from 'board/registers'
+import { InstructionError } from 'instruction/error'
+import { getBits, getEnumValueForRegisterString } from 'instruction/opcode'
+import { Halfword } from 'types/binary'
+import { BaseInstruction } from '../base'
+
+export abstract class StackInstruction extends BaseInstruction {
+  public pattern: string = '1011X10XXXXXXXXX'
+  /**
+   * PC for pop instruction and LR for push instruction
+   */
+  protected abstract additionalRegister: Register
+  private registerBitsPattern: string = '1011010XXXXXXXXX'
+  private lrOrPcRegisterPosition = 8
+  protected setStackRegisterBits(
+    opcode: Halfword,
+    options: string[]
+  ): Halfword {
+    let registers = this.getRegisters(options)
+
+    for (const register of registers) {
+      if (Registers.isLowRegister(register)) {
+        opcode = opcode.setBit(register)
+      } else if (this.correctLrOrPcRegisterProvided(register)) {
+        opcode = opcode.setBit(this.lrOrPcRegisterPosition)
+      }
+    }
+
+    return Halfword.fromUnsignedInteger(0)
+  }
+  protected getStackRegisterFromOpcode(opcode: Halfword): Register[] {
+    const registerList = getBits(opcode, this.registerBitsPattern)
+    const registerValues: Register[] = []
+    for (let i = 0; i <= this.lrOrPcRegisterPosition; i++) {
+      if (registerList.isBitSet(i)) {
+        registerValues.push(i)
+      }
+    }
+    return registerValues
+  }
+
+  private correctLrOrPcRegisterProvided(register: Register): boolean {
+    return register !== this.additionalRegister
+  }
+
+  private getRegisters(options: string[]): Register[] {
+    const registers: Register[] = []
+    options[0] = options[0].replace('{', '').trim()
+    options[options.length - 1] = options[options.length - 1]
+      .replace('}', '')
+      .trim()
+
+    for (const option of options) {
+      if (option.includes('-')) {
+        const values = option.split('-')
+        const start = this.getRegister(values[0])
+        const end = this.getRegister(values[1])
+        this.getRegisterRange(start, end).forEach((r) =>
+          this.addRegisterToList(registers, r)
+        )
+      } else {
+        this.addRegisterToList(registers, this.getRegister(option))
+      }
+    }
+    return registers
+  }
+
+  private addRegisterToList(list: Register[], register: Register) {
+    if (list.includes(register)) {
+      throw new InstructionError(
+        `Register ${register} multiple times provided in stack options.`
+      )
+    }
+    list.push(register)
+  }
+
+  private getRegisterRange(start: Register, end: Register): Register[] {
+    const registers: Register[] = []
+    if (start > end) {
+      throw new InstructionError('End of range can not be before start of it.')
+    }
+    for (let i = start; i <= end; i++) {
+      registers.push(i)
+    }
+
+    return registers
+  }
+
+  private getRegister(value: string): Register {
+    const register = getEnumValueForRegisterString(value.trim())
+    if (
+      !Registers.isLowRegister(register) &&
+      !this.correctLrOrPcRegisterProvided(register)
+    ) {
+      throw new InstructionError(
+        'Provided register is not a low register or the LR register.'
+      )
+    }
+    return register
+  }
+
+  /**
+   * Convenience method to throw an InstructionError if encoder is not called with correctly set curly brackets.
+   * If only one option provided this param has to have opening and closing brackets and
+   * other wise opening on first and closing on last param expected.
+   * @param options parameter provided to encodeInstruction method
+   */
+  protected checkCurlyBracketsOnOptions(options: string[]): void {
+    if (!this.stackOptionsEnclosedInCurlyBrackets(options)) {
+      if (options.length == 1) {
+        throw new InstructionError(
+          `Opening or closing curly bracket missing for 1. param.`
+        )
+      }
+    } else {
+      throw new InstructionError(
+        `Opening curly bracket on 1. param or closing bracket on ${
+          options.length - 1
+        }. param missing.`
+      )
+    }
+  }
+
+  /**
+   * Checks if the curly brackets are set correct on the stack options.
+   * @param options where to check for the left bracket and right bracket
+   * @returns true if the brackets are set correct
+   */
+  private stackOptionsEnclosedInCurlyBrackets(options: string[]): boolean {
+    return (
+      options.length >= 1 &&
+      options[0].startsWith('{') &&
+      options[options.length - 1].endsWith('}')
+    )
+  }
+}

--- a/src/instruction/opcode.ts
+++ b/src/instruction/opcode.ts
@@ -274,7 +274,7 @@ export function isLowRegister(possibleLowRegister: string): boolean {
  * @param option string to convert
  * @returns valid value for enum Register
  */
-function getEnumValueForRegisterString(option: string): Register {
+export function getEnumValueForRegisterString(option: string): Register {
   try {
     return $enum(Register).getValueOrThrow(option)
   } catch (e) {

--- a/src/instruction/set.ts
+++ b/src/instruction/set.ts
@@ -78,6 +78,7 @@ import {
   LsrsRegisterInstruction
 } from './instructions/shift_rotate/lsrs'
 import { RorsInstruction } from './instructions/shift_rotate/rors'
+import { PopInstruction } from './instructions/stack/pop'
 import {
   StrImmediate5OffsetInstruction,
   StrRegisterOffsetInstruction
@@ -202,5 +203,6 @@ export default new InstructionSet([
   new BGTConditionalJumpInstruction(),
   new BLEConditionalJumpInstruction(),
   new BALConditionalJumpInstruction(),
-  new PushInstruction()
+  new PushInstruction(),
+  new PopInstruction()
 ])

--- a/src/instruction/set.ts
+++ b/src/instruction/set.ts
@@ -21,6 +21,7 @@ import {
 import { BlInstruction } from 'instruction/instructions/jump/bl'
 import { BlxInstruction } from 'instruction/instructions/jump/blx'
 import { BxInstruction } from 'instruction/instructions/jump/bx'
+import { PushInstruction } from 'instruction/instructions/stack/push'
 import { Halfword } from 'types/binary'
 import { AdcsInstruction } from './instructions/add/adcs'
 import { AddInstruction } from './instructions/add/add'
@@ -200,5 +201,6 @@ export default new InstructionSet([
   new BLTConditionalJumpInstruction(),
   new BGTConditionalJumpInstruction(),
   new BLEConditionalJumpInstruction(),
-  new BALConditionalJumpInstruction()
+  new BALConditionalJumpInstruction(),
+  new PushInstruction()
 ])

--- a/test/instruction/instructions/stack/pop.test.ts
+++ b/test/instruction/instructions/stack/pop.test.ts
@@ -1,0 +1,185 @@
+import { Memory } from 'board/memory'
+import { Register, Registers } from 'board/registers'
+import { InstructionError } from 'instruction/error'
+import { PopInstruction } from 'instruction/instructions/stack/pop'
+import { Halfword, Word } from 'types/binary'
+
+const instr = new PopInstruction()
+
+const registers: Registers = new Registers()
+const memory: Memory = new Memory()
+
+describe('test canEncodeInstruction (wheter the class is responsible for this command) function', () => {
+  test('POP instruction', () => {
+    expect(instr.canEncodeInstruction('INVALID', ['{R2', 'R7}'])).toBe(false)
+    expect(instr.canEncodeInstruction('POP', ['[R2', 'R7]'])).toBe(true)
+    expect(instr.canEncodeInstruction('POP', ['R2}', '{R7}'])).toBe(true)
+    expect(instr.canEncodeInstruction('POP', ['{R2', 'R7'])).toBe(true)
+    expect(instr.canEncodeInstruction('POP', ['{R2', 'R7 }'])).toBe(true)
+    expect(instr.canEncodeInstruction('POP', ['{R5', 'R5}'])).toBe(true)
+    expect(instr.canEncodeInstruction('POP', ['{R2', 'PC', 'R7}'])).toBe(true)
+    expect(instr.canEncodeInstruction('POP', ['{R2 -R6}'])).toBe(true)
+    expect(instr.canEncodeInstruction('POP', ['{R3-R1}'])).toBe(true)
+    expect(instr.canEncodeInstruction('POP', ['{R2- R6', 'R0}'])).toBe(true)
+    expect(instr.canEncodeInstruction('POP', ['{ PC}'])).toBe(true)
+    expect(instr.canEncodeInstruction('POP', ['{LR}'])).toBe(true)
+    expect(
+      instr.canEncodeInstruction('POP', [
+        '{R5',
+        'PC',
+        'R1',
+        'R7',
+        'R6',
+        'R0',
+        'R3',
+        'R2',
+        'R4}'
+      ])
+    ).toBe(true)
+  })
+})
+
+describe('test encodeInstruction (command with options --> optcode) function', () => {
+  test('POP', () => {
+    expect(instr.encodeInstruction(['{R2', 'R7}'])[0].toBinaryString()).toEqual(
+      '1011110010000100'
+    )
+    expect(instr.encodeInstruction(['{R5', 'R1}'])[0].toBinaryString()).toEqual(
+      '1011110000100010'
+    )
+    expect(
+      instr.encodeInstruction(['{ PC', 'R7}'])[0].toBinaryString()
+    ).toEqual('1011110110000000')
+    expect(instr.encodeInstruction(['{R0', 'PC}'])[0].toBinaryString()).toEqual(
+      '1011110100000001'
+    )
+    expect(
+      instr.encodeInstruction(['{  R3-R6', 'R0-R1}'])[0].toBinaryString()
+    ).toEqual('1011110001111011')
+    expect(
+      instr.encodeInstruction(['{R2', 'R4', 'R6 }'])[0].toBinaryString()
+    ).toEqual('1011110001010100')
+    expect(
+      instr.encodeInstruction(['{R3', 'PC', 'R7', 'R5}'])[0].toBinaryString()
+    ).toEqual('1011110110101000')
+    expect(instr.encodeInstruction(['{R2 -R6}'])[0].toBinaryString()).toEqual(
+      '1011110001111100'
+    )
+    expect(instr.encodeInstruction(['{R0-R7}'])[0].toBinaryString()).toEqual(
+      '1011110011111111'
+    )
+    expect(
+      instr.encodeInstruction(['{R3- R3', 'R0}'])[0].toBinaryString()
+    ).toEqual('1011110000001001')
+    expect(instr.encodeInstruction(['{PC}'])[0].toBinaryString()).toEqual(
+      '1011110100000000'
+    )
+    expect(
+      instr
+        .encodeInstruction([
+          '{R5',
+          'PC',
+          'R1',
+          'R7',
+          'R6',
+          'R0',
+          'R3',
+          'R2',
+          'R4}'
+        ])[0]
+        .toBinaryString()
+    ).toEqual('1011110111111111')
+
+    expect(() => instr.encodeInstruction(['invalidOption'])).toThrow(
+      InstructionError
+    )
+    expect(() => instr.encodeInstruction(['[R7', 'R5]'])).toThrow(
+      InstructionError
+    )
+    expect(() => instr.encodeInstruction(['R2}', '{R7}'])).toThrow(
+      InstructionError
+    )
+    expect(() => instr.encodeInstruction([])).toThrow(InstructionError)
+    expect(() => instr.encodeInstruction(['{R2', 'R7'])).toThrow(
+      InstructionError
+    )
+    expect(() => instr.encodeInstruction(['{R5', 'R5}'])).toThrow(
+      InstructionError
+    )
+    expect(() => instr.encodeInstruction(['{LR}'])).toThrow(InstructionError)
+    expect(() => instr.encodeInstruction(['{R6-R3}'])).toThrow(InstructionError)
+    expect(() => instr.encodeInstruction(['{R8}'])).toThrow(InstructionError)
+    expect(() => instr.encodeInstruction(['{R77}'])).toThrow(InstructionError)
+  })
+})
+
+describe('test executeInstruction function', () => {
+  test('LDR byte with sign extension', () => {
+    let stackAddress = Word.fromUnsignedInteger(0x2000199e)
+    const topOfStackVal = Word.fromUnsignedInteger(0xfedc4321)
+    const stackVal2 = Word.fromUnsignedInteger(0x22443355)
+    const stackVal3 = Word.fromUnsignedInteger(0x03050208)
+    const stackVal4 = Word.fromUnsignedInteger(0xe05011c0)
+    const stackVal5 = Word.fromUnsignedInteger(0x57382548)
+    const stackVal6 = Word.fromUnsignedInteger(0x03002405)
+    registers.writeRegister(Register.SP, stackAddress)
+    memory.writeWord(stackAddress, topOfStackVal)
+    memory.writeWord(stackAddress.add(4), stackVal2)
+    memory.writeWord(stackAddress.add(8), stackVal3)
+    memory.writeWord(stackAddress.add(12), stackVal4)
+    memory.writeWord(stackAddress.add(16), stackVal5)
+    memory.writeWord(stackAddress.add(20), stackVal6)
+
+    instr.executeInstruction(
+      [Halfword.fromUnsignedInteger(0b1011110000100010)], //POP {R1, R5}
+      registers,
+      memory
+    )
+
+    expect(registers.readRegister(Register.R5)).toEqual(topOfStackVal)
+    expect(registers.readRegister(Register.R1)).toEqual(stackVal2)
+    expect(registers.readRegister(Register.SP).value).toEqual(
+      stackAddress.add(8)
+    )
+
+    instr.executeInstruction(
+      [Halfword.fromUnsignedInteger(0b1011110110101000)], //POP {R3, PC, R7, R5}
+      registers,
+      memory
+    )
+
+    expect(registers.readRegister(Register.PC)).toEqual(stackVal3)
+    expect(registers.readRegister(Register.R7)).toEqual(stackVal4)
+    expect(registers.readRegister(Register.R5)).toEqual(stackVal5)
+    expect(registers.readRegister(Register.R3)).toEqual(stackVal6)
+
+    expect(registers.readRegister(Register.SP).value).toEqual(
+      stackAddress.add(16)
+    )
+
+    registers.reset()
+    registers.writeRegister(Register.SP, stackAddress)
+
+    instr.executeInstruction(
+      [Halfword.fromUnsignedInteger(0b1011110100000000)], //POP {PC}
+      registers,
+      memory
+    )
+
+    expect(registers.readRegister(Register.PC)).toEqual(topOfStackVal)
+    expect(registers.readRegister(Register.R7).value).toEqual(0)
+    expect(registers.readRegister(Register.R0).value).toEqual(0)
+
+    instr.executeInstruction(
+      [Halfword.fromUnsignedInteger(0b1011110100100111)], //POP {R6, R0-R2}
+      registers,
+      memory
+    )
+
+    expect(registers.readRegister(Register.PC)).toEqual(topOfStackVal)
+    expect(registers.readRegister(Register.R6)).toEqual(stackVal2)
+    expect(registers.readRegister(Register.R2)).toEqual(stackVal3)
+    expect(registers.readRegister(Register.R1)).toEqual(stackVal4)
+    expect(registers.readRegister(Register.R0)).toEqual(stackVal5)
+  })
+})

--- a/test/instruction/instructions/stack/push.test.ts
+++ b/test/instruction/instructions/stack/push.test.ts
@@ -135,6 +135,7 @@ describe('test executeInstruction function', () => {
       memory
     )
 
+    expect(registers.readRegister(Register.SP)).toEqual(stackAddress.add(-8))
     expect(memory.readWord(registers.readRegister(Register.SP))).toEqual(value2)
     expect(memory.readWord(registers.readRegister(Register.SP).add(4))).toEqual(
       value3
@@ -146,6 +147,7 @@ describe('test executeInstruction function', () => {
       memory
     )
 
+    expect(registers.readRegister(Register.SP)).toEqual(stackAddress.add(-24))
     expect(memory.readWord(registers.readRegister(Register.SP))).toEqual(value1)
     expect(memory.readWord(registers.readRegister(Register.SP).add(4))).toEqual(
       value3
@@ -163,6 +165,7 @@ describe('test executeInstruction function', () => {
       memory
     )
 
+    expect(registers.readRegister(Register.SP)).toEqual(stackAddress.add(-28))
     expect(memory.readWord(registers.readRegister(Register.SP))).toEqual(value5)
 
     instr.executeInstruction(
@@ -171,6 +174,7 @@ describe('test executeInstruction function', () => {
       memory
     )
 
+    expect(registers.readRegister(Register.SP)).toEqual(stackAddress.add(-44))
     expect(memory.readWord(registers.readRegister(Register.SP))).toEqual(value1)
     expect(memory.readWord(registers.readRegister(Register.SP).add(4))).toEqual(
       value2

--- a/test/instruction/instructions/stack/push.test.ts
+++ b/test/instruction/instructions/stack/push.test.ts
@@ -1,0 +1,185 @@
+import { Memory } from 'board/memory'
+import { Register, Registers } from 'board/registers'
+import { InstructionError } from 'instruction/error'
+import { PushInstruction } from 'instruction/instructions/stack/push'
+import { Halfword, Word } from 'types/binary'
+
+const instr = new PushInstruction()
+
+const registers: Registers = new Registers()
+const memory: Memory = new Memory()
+
+describe('test canEncodeInstruction (whether the class is responsible for this command) function', () => {
+  test('PUSH instruction', () => {
+    expect(instr.canEncodeInstruction('INVALID', ['{R2', 'R7}'])).toBe(false)
+    expect(instr.canEncodeInstruction('PUSH', ['[R2', 'R7]'])).toBe(true)
+    expect(instr.canEncodeInstruction('PUSH', ['R2}', '{R7}'])).toBe(true)
+    expect(instr.canEncodeInstruction('PUSH', ['{R2', 'R7'])).toBe(true)
+    expect(instr.canEncodeInstruction('PUSH', ['{R2', 'R7 }'])).toBe(true)
+    expect(instr.canEncodeInstruction('PUSH', ['{R5', 'R5}'])).toBe(true)
+    expect(instr.canEncodeInstruction('PUSH', ['{R2', 'LR', 'R7}'])).toBe(true)
+    expect(instr.canEncodeInstruction('PUSH', ['{R2 -R6}'])).toBe(true)
+    expect(instr.canEncodeInstruction('PUSH', ['{R3-R1}'])).toBe(true)
+    expect(instr.canEncodeInstruction('PUSH', ['{R2- R6', 'R0}'])).toBe(true)
+    expect(instr.canEncodeInstruction('PUSH', ['{ PC}'])).toBe(true)
+    expect(instr.canEncodeInstruction('PUSH', ['{LR}'])).toBe(true)
+    expect(
+      instr.canEncodeInstruction('PUSH', [
+        '{R5',
+        'LR',
+        'R1',
+        'R7',
+        'R6',
+        'R0',
+        'R3',
+        'R2',
+        'R4}'
+      ])
+    ).toBe(true)
+  })
+})
+
+describe('test encodeInstruction (command with options --> optcode) function', () => {
+  test('PUSH', () => {
+    expect(instr.encodeInstruction(['{R2', 'R7}'])[0].toBinaryString()).toEqual(
+      '1011010010000100'
+    )
+    expect(instr.encodeInstruction(['{R5', 'R1}'])[0].toBinaryString()).toEqual(
+      '1011010000100010'
+    )
+    expect(
+      instr.encodeInstruction(['{ LR', 'R7}'])[0].toBinaryString()
+    ).toEqual('1011010110000000')
+    expect(instr.encodeInstruction(['{R0', 'LR}'])[0].toBinaryString()).toEqual(
+      '1011010100000001'
+    )
+    expect(
+      instr.encodeInstruction(['{  R3-R6', 'R0-R1}'])[0].toBinaryString()
+    ).toEqual('1011010001111011')
+    expect(
+      instr.encodeInstruction(['{R2', 'R4', 'R6 }'])[0].toBinaryString()
+    ).toEqual('1011010001010100')
+    expect(
+      instr.encodeInstruction(['{R3', 'LR', 'R7', 'R5}'])[0].toBinaryString()
+    ).toEqual('1011010110101000')
+    expect(instr.encodeInstruction(['{R2 -R6}'])[0].toBinaryString()).toEqual(
+      '1011010001111100'
+    )
+    expect(instr.encodeInstruction(['{R0-R7}'])[0].toBinaryString()).toEqual(
+      '1011010011111111'
+    )
+    expect(
+      instr.encodeInstruction(['{R3- R3', 'R0}'])[0].toBinaryString()
+    ).toEqual('1011010000001001')
+    expect(instr.encodeInstruction(['{LR}'])[0].toBinaryString()).toEqual(
+      '1011010100000000'
+    )
+    expect(
+      instr
+        .encodeInstruction([
+          '{R5',
+          'LR',
+          'R1',
+          'R7',
+          'R6',
+          'R0',
+          'R3',
+          'R2',
+          'R4}'
+        ])[0]
+        .toBinaryString()
+    ).toEqual('1011010111111111')
+
+    expect(() => instr.encodeInstruction(['invalidOption'])).toThrow(
+      InstructionError
+    )
+    expect(() => instr.encodeInstruction(['[R7', 'R5]'])).toThrow(
+      InstructionError
+    )
+    expect(() => instr.encodeInstruction(['R2}', '{R7}'])).toThrow(
+      InstructionError
+    )
+    expect(() => instr.encodeInstruction([])).toThrow(InstructionError)
+    expect(() => instr.encodeInstruction(['{R2', 'R7'])).toThrow(
+      InstructionError
+    )
+    expect(() => instr.encodeInstruction(['{R5', 'R5}'])).toThrow(
+      InstructionError
+    )
+    expect(() => instr.encodeInstruction(['{PC}'])).toThrow(InstructionError)
+    expect(() => instr.encodeInstruction(['{R6-R3}'])).toThrow(InstructionError)
+    expect(() => instr.encodeInstruction(['{R8}'])).toThrow(InstructionError)
+    expect(() => instr.encodeInstruction(['{R77}'])).toThrow(InstructionError)
+  })
+})
+
+describe('test executeInstruction function', () => {
+  test('PUSH instruction', () => {
+    let stackAddress = Word.fromUnsignedInteger(0x2000199e)
+    const value1 = Word.fromUnsignedInteger(0x22443355)
+    const value2 = Word.fromUnsignedInteger(0x03050208)
+    const value3 = Word.fromUnsignedInteger(0xe05011c0)
+    const value4 = Word.fromUnsignedInteger(0x57382548)
+    const value5 = Word.fromUnsignedInteger(0x03002405)
+    registers.writeRegister(Register.SP, stackAddress)
+    registers.writeRegister(Register.R0, value1)
+    registers.writeRegister(Register.R1, value2)
+    registers.writeRegister(Register.R2, value2)
+    registers.writeRegister(Register.R5, value3)
+    registers.writeRegister(Register.R7, value4)
+    registers.writeRegister(Register.LR, value5)
+
+    instr.executeInstruction(
+      [Halfword.fromUnsignedInteger(0b1011010000100010)], //PUSH {R1, R5}
+      registers,
+      memory
+    )
+
+    expect(memory.readWord(registers.readRegister(Register.SP))).toEqual(value2)
+    expect(memory.readWord(registers.readRegister(Register.SP).add(4))).toEqual(
+      value3
+    )
+
+    instr.executeInstruction(
+      [Halfword.fromUnsignedInteger(0b1011010110100001)], //PUSH {R0, LR, R7, R5}
+      registers,
+      memory
+    )
+
+    expect(memory.readWord(registers.readRegister(Register.SP))).toEqual(value1)
+    expect(memory.readWord(registers.readRegister(Register.SP).add(4))).toEqual(
+      value3
+    )
+    expect(memory.readWord(registers.readRegister(Register.SP).add(8))).toEqual(
+      value4
+    )
+    expect(
+      memory.readWord(registers.readRegister(Register.SP).add(12))
+    ).toEqual(value5)
+
+    instr.executeInstruction(
+      [Halfword.fromUnsignedInteger(0b1011010100000000)], //PUSH {LR}
+      registers,
+      memory
+    )
+
+    expect(memory.readWord(registers.readRegister(Register.SP))).toEqual(value5)
+
+    instr.executeInstruction(
+      [Halfword.fromUnsignedInteger(0b1011010010000111)], //PUSH {R7, R0-R2}
+      registers,
+      memory
+    )
+
+    expect(memory.readWord(registers.readRegister(Register.SP))).toEqual(value1)
+    expect(memory.readWord(registers.readRegister(Register.SP).add(4))).toEqual(
+      value2
+    )
+    expect(memory.readWord(registers.readRegister(Register.SP).add(8))).toEqual(
+      value2
+    )
+    expect(
+      memory.readWord(registers.readRegister(Register.SP).add(12))
+    ).toEqual(value4)
+  })
+})


### PR DESCRIPTION
Example code
stack pointer decreases per iteration by 32 (since values of R1- R7 and LR are only pushed but not popped)
```
AREA myCode, CODE, READONLY
start
  MOVS R1, #44
  MOVS R2, #2
  PUSH { R2,R1}
  POP { R4-R5 }
  PUSH {LR}
  POP {R7}
  LDR R0, =start
  PUSH {R0-R7}
  POP {PC}

```