### PR TITLE
VCB-189 fix: add support for equ constant in brackets

### DIFF
--- a/src/assembler/encoder.ts
+++ b/src/assembler/encoder.ts
@@ -112,16 +112,27 @@ function replaceEquConstants(
   equConstants: Map<string, Word>
 ): void {
   for (let i = 0; i < instruction.options.length; i++) {
+    const hasEndingBracket = instruction.options[i].endsWith(']')
     if (
       instruction.options[i].startsWith('#') &&
-      isNaN(+instruction.options[i].slice(1))
+      ((!hasEndingBracket && isNaN(+instruction.options[i].slice(1))) ||
+        (hasEndingBracket &&
+          isNaN(
+            +instruction.options[i].slice(1, instruction.options[i].length - 1)
+          )))
     ) {
-      const val = equConstants.get(instruction.options[i].slice(1))
-      if (val) {
+      const equName = hasEndingBracket
+        ? instruction.options[i].slice(1, instruction.options[i].length - 1)
+        : instruction.options[i].slice(1)
+      const val = equConstants.get(equName)
+
+      if (val && !hasEndingBracket) {
         instruction.options[i] = '#' + val.toUnsignedInteger().toString()
+      } else if (val && hasEndingBracket) {
+        instruction.options[i] = '#' + val.toUnsignedInteger().toString() + ']'
       } else {
         throw new AssemblerError(
-          `Instruction refers to constant ${instruction.options[i]} which does not exists.`,
+          `Instruction refers to constant #${equName} which does not exists.`,
           instruction.line
         )
       }

--- a/test/assembler/encoder.test.ts
+++ b/test/assembler/encoder.test.ts
@@ -380,6 +380,34 @@ describe('encode', function () {
     expect(file.content[0].value).toBe(0xb)
     expect(file.content[1].value).toBe(0x21)
   })
+  it('should encode code instruction that references equ constant within brackets', function () {
+    const code: ICodeFile = {
+      symbols: {
+        ['MY_CONST']: '0x0'
+      },
+      areas: [
+        {
+          type: AreaType.Code,
+          isReadOnly: true,
+          name: '|.code|',
+          instructions: [
+            {
+              name: 'STRB',
+              options: ['R1', '[R0', '#MY_CONST]'],
+              line: 0
+            }
+          ]
+        }
+      ]
+    }
+    const file = encode(code)
+    expect(Object.keys(file.sections).length).toBe(1)
+    expect(getSection(file, '|.code|').offset).toBe(0)
+    expect(getSection(file, '|.code|').size).toBe(2)
+    expect(file.content.length).toBe(2)
+    expect(file.content[0].value).toBe(0x01)
+    expect(file.content[1].value).toBe(0x70)
+  })
   it('should throw error if instruction references unknown equ constant', function () {
     const code: ICodeFile = {
       symbols: {


### PR DESCRIPTION
Should work now:
```
AREA |.code|, CODE, READWRITE
  TEST EQU 0x0
  STRB R1,[R0,#0]
```

Should work now:
```
AREA |.code|, CODE, READWRITE
  TEST EQU 0x0
  STRB R1,[R0,#TEST]
```

Should still work:
```
AREA |.code|,CODE, READWRITE
  TEST EQU 0xB
  MOVS R0,#0xB
  MOVS R1,#TEST
```