### PR TITLE
VCB-177 Fix alignment

### DIFF
--- a/src/assembler/elf/writer.ts
+++ b/src/assembler/elf/writer.ts
@@ -164,7 +164,7 @@ export class FileWriter {
       if (off) {
         const fill = alignment - off
         this.file.content.push(
-          ...Array(fill).fill(Byte.fromUnsignedInteger(0xff))
+          ...Array(fill).fill(Byte.fromUnsignedInteger(0x00))
         )
       }
     }
@@ -175,8 +175,7 @@ export class FileWriter {
    *
    * @param bytes the bytes to write
    */
-  public writeBytes(bytes: Byte[], alignment?: number): void {
-    if (alignment) this.align(alignment)
+  public writeBytes(bytes: Byte[]): void {
     this.file.content.push(...bytes)
   }
 

--- a/src/assembler/elf/writer.ts
+++ b/src/assembler/elf/writer.ts
@@ -153,7 +153,7 @@ export class FileWriter {
   }
 
   /**
-   * Aligns the content to be specified alignment by filling.
+   * Aligns the content to be specified alignment by filling zeros bytes.
    *
    * @param alignment the alignment (e.g. 2 for halfword and 4 for word alignment)
    */

--- a/src/assembler/encoder.ts
+++ b/src/assembler/encoder.ts
@@ -282,8 +282,8 @@ function writeDataInstruction(
 ): void {
   if (isSymbolDataInstruction(instruction)) {
     const bytes = Word.fromUnsignedInteger(0x0).toBytes()
+    writer.align(4)
     for (const option of instruction.options) {
-      writer.align(4)
       writer.addDataRelocation(option, bytes.length)
       writer.writeBytes(bytes)
     }

--- a/src/assembler/encoder.ts
+++ b/src/assembler/encoder.ts
@@ -354,7 +354,7 @@ function writeCodeInstruction(
  */
 function writeLiteralPool(writer: FileWriter, pool: ILiteralPool) {
   if (pool.entries.length > 0) {
-    // To ensure that it's not possible to for the processor to 'fall into'
+    // To ensure that it's not possible for the processor to 'fall into'
     // the literal pool, we add a 'END_OF_CODE' instruction before the literal pool.
     writer.align(2)
     writer.writeBytes(END_OF_CODE.toBytes())

--- a/src/assembler/encoder.ts
+++ b/src/assembler/encoder.ts
@@ -354,8 +354,13 @@ function writeCodeInstruction(
  */
 function writeLiteralPool(writer: FileWriter, pool: ILiteralPool) {
   if (pool.entries.length > 0) {
+    // To ensure that it's not possible to for the processor to 'fall into'
+    // the literal pool, we add a 'END_OF_CODE' instruction before the literal pool.
     writer.align(2)
     writer.writeBytes(END_OF_CODE.toBytes())
+    // Because the offset to the 'DCD' instruction is calculated before the data instruction
+    // is written and we want the offset to include the alignment, we word align everything
+    // before writing the literal pool.
     writer.align(4)
     for (const entry of pool.entries) {
       const encoder = InstructionSet.getEncoder(

--- a/src/assembler/linker.ts
+++ b/src/assembler/linker.ts
@@ -98,8 +98,9 @@ function writeCodeSegment(writer: FileWriter, objectFile: IELF): void {
   writer.writeBytes(VECTOR_TABLE)
   for (const section of getSectionsOfType(objectFile, SectionType.Code)) {
     writeSection(writer, objectFile, section)
+    writer.writeBytes(END_OF_CODE.toBytes())
+    writer.align(4)
   }
-  writer.writeBytes(END_OF_CODE.toBytes())
   writer.endSegment()
 }
 
@@ -116,6 +117,7 @@ function writeDataSegment(writer: FileWriter, objectFile: IELF): void {
     writer.startSegment(SegmentType.Load, SRAM_START)
     for (const section of sections) {
       writeSection(writer, objectFile, section)
+      writer.align(4)
     }
     writer.endSegment()
   }
@@ -139,7 +141,6 @@ function writeSection(
     section.offset + section.size
   )
   writer.writeBytes(bytes)
-  writer.align(4)
   addAddressSymbols(writer, objectFile, section)
   writer.endSection()
 }

--- a/src/assembler/linker.ts
+++ b/src/assembler/linker.ts
@@ -139,6 +139,7 @@ function writeSection(
     section.offset + section.size
   )
   writer.writeBytes(bytes)
+  writer.align(4)
   addAddressSymbols(writer, objectFile, section)
   writer.endSection()
 }

--- a/test/assembler/encoder.test.ts
+++ b/test/assembler/encoder.test.ts
@@ -199,7 +199,7 @@ describe('encode', function () {
           instructions: [
             {
               name: 'DCB',
-              options: ['0x0'],
+              options: ['0x1'],
               line: 0
             },
             {
@@ -216,10 +216,10 @@ describe('encode', function () {
     expect(getSection(file, '|.data|').offset).toBe(0)
     expect(getSection(file, '|.data|').size).toBe(4)
     expect(file.content.length).toBe(4)
-    expect(file.content[0].value).toBe(0x00)
-    expect(file.content[1].value).toBe(0xff)
-    expect(file.content[2].value).toBe(0xff)
-    expect(file.content[3].value).toBe(0xff)
+    expect(file.content[0].value).toBe(0x01)
+    expect(file.content[1].value).toBe(0x00)
+    expect(file.content[2].value).toBe(0x00)
+    expect(file.content[3].value).toBe(0x00)
   })
   it('should should align code instruction', function () {
     const code: ICodeFile = {
@@ -250,7 +250,7 @@ describe('encode', function () {
     expect(getSection(file, '|.text|').size).toBe(4)
     expect(file.content.length).toBe(4)
     expect(file.content[0].value).toBe(0x00)
-    expect(file.content[1].value).toBe(0xff)
+    expect(file.content[1].value).toBe(0x00)
     expect(file.content[2].value).toBe(0x11)
     expect(file.content[3].value).toBe(0x0)
   })
@@ -283,15 +283,15 @@ describe('encode', function () {
     expect(getSection(file, '|.text|').size).toBe(16)
     expect(file.content.length).toBe(16)
     expect(Halfword.fromBytes(file.content[0], file.content[1])).toEqual(
-      Halfword.fromUnsignedInteger(0x4904)
+      Halfword.fromUnsignedInteger(0x4906)
     )
     expect(Halfword.fromBytes(file.content[2], file.content[3])).toEqual(
       Halfword.fromUnsignedInteger(0x4a08)
     )
     expect(file.content[4]).toEqual(Byte.fromUnsignedInteger(0xff))
     expect(file.content[5]).toEqual(Byte.fromUnsignedInteger(0xff))
-    expect(file.content[6]).toEqual(Byte.fromUnsignedInteger(0xff))
-    expect(file.content[7]).toEqual(Byte.fromUnsignedInteger(0xff))
+    expect(file.content[6]).toEqual(Byte.fromUnsignedInteger(0x00))
+    expect(file.content[7]).toEqual(Byte.fromUnsignedInteger(0x00))
     expect(
       Word.fromBytes(
         file.content[8],

--- a/test/assembler/linker.test.ts
+++ b/test/assembler/linker.test.ts
@@ -209,7 +209,7 @@ describe('linker', function () {
           instructions: [
             {
               name: 'DCW',
-              options: ['0x2222'],
+              options: ['0x3333'],
               line: 1
             }
           ]
@@ -221,12 +221,12 @@ describe('linker', function () {
           instructions: [
             {
               name: 'MOVS',
-              options: ['R1', 'R1'],
+              options: ['R1', 'R2'],
               line: 2
             },
             {
               name: 'MOVS',
-              options: ['R2', 'R2'],
+              options: ['R1', 'R2'],
               line: 3
             }
           ]
@@ -243,6 +243,43 @@ describe('linker', function () {
     expect(file.segments[1].offset).toBe(16)
     expect(file.segments[1].size).toBe(8)
     expect(file.segments[1].address).toEqual(Word.fromSignedInteger(0x20000000))
+    expect(file.content.length).toBe(24)
+    expect(
+      Word.fromBytes(
+        file.content[0],
+        file.content[1],
+        file.content[2],
+        file.content[3]
+      )
+    ).toEqual(Word.fromUnsignedInteger(0x20002000))
+    expect(
+      Word.fromBytes(
+        file.content[4],
+        file.content[5],
+        file.content[6],
+        file.content[7]
+      )
+    ).toEqual(Word.fromUnsignedInteger(0x08000008))
+    expect(Halfword.fromBytes(file.content[8], file.content[9])).toEqual(
+      Halfword.fromUnsignedInteger(0x0011)
+    )
+    expect(Halfword.fromBytes(file.content[10], file.content[11])).toEqual(
+      Halfword.fromUnsignedInteger(0x0011)
+    )
+    expect(Halfword.fromBytes(file.content[12], file.content[13])).toEqual(
+      END_OF_CODE
+    )
+    expect(Halfword.fromBytes(file.content[14], file.content[15])).toEqual(
+      Halfword.fromUnsignedInteger(0x0000)
+    )
+    expect(file.content[16]).toEqual(Byte.fromUnsignedInteger(0x22))
+    expect(file.content[17]).toEqual(Byte.fromUnsignedInteger(0x00))
+    expect(file.content[18]).toEqual(Byte.fromUnsignedInteger(0x00))
+    expect(file.content[19]).toEqual(Byte.fromUnsignedInteger(0x00))
+    expect(file.content[20]).toEqual(Byte.fromUnsignedInteger(0x33))
+    expect(file.content[21]).toEqual(Byte.fromUnsignedInteger(0x33))
+    expect(file.content[22]).toEqual(Byte.fromUnsignedInteger(0x00))
+    expect(file.content[23]).toEqual(Byte.fromUnsignedInteger(0x00))
   })
   it('should apply data relocations', function () {
     const code: ICodeFile = {

--- a/test/assembler/linker.test.ts
+++ b/test/assembler/linker.test.ts
@@ -50,16 +50,16 @@ describe('linker', function () {
     expect(file.segments.length).toBe(1)
     expect(file.segments[0].type).toBe(SegmentType.Load)
     expect(file.segments[0].offset).toBe(0)
-    expect(file.segments[0].size).toBe(18)
+    expect(file.segments[0].size).toBe(24)
     expect(file.segments[0].address).toEqual(Word.fromSignedInteger(0x08000000))
     expect(file.sections.length).toBe(0)
     expect(Object.keys(file.symbols).length).toBe(0)
     expect(file.relocations.length).toBe(0)
     expect(file.sourceMap.getLine(Word.fromSignedInteger(0x08000008))).toBe(0)
     expect(file.sourceMap.getLine(Word.fromSignedInteger(0x0800000a))).toBe(1)
-    expect(file.sourceMap.getLine(Word.fromSignedInteger(0x0800000c))).toBe(2)
-    expect(file.sourceMap.getLine(Word.fromSignedInteger(0x0800000e))).toBe(3)
-    expect(file.content.length).toBe(18)
+    expect(file.sourceMap.getLine(Word.fromSignedInteger(0x08000010))).toBe(2)
+    expect(file.sourceMap.getLine(Word.fromSignedInteger(0x08000012))).toBe(3)
+    expect(file.content.length).toBe(24)
     expect(
       Word.fromBytes(
         file.content[0],
@@ -83,13 +83,22 @@ describe('linker', function () {
       Halfword.fromUnsignedInteger(0x0011)
     )
     expect(Halfword.fromBytes(file.content[12], file.content[13])).toEqual(
-      Halfword.fromUnsignedInteger(0x0011)
+      END_OF_CODE
     )
     expect(Halfword.fromBytes(file.content[14], file.content[15])).toEqual(
-      Halfword.fromUnsignedInteger(0x0011)
+      Halfword.fromUnsignedInteger(0x0000)
     )
     expect(Halfword.fromBytes(file.content[16], file.content[17])).toEqual(
+      Halfword.fromUnsignedInteger(0x0011)
+    )
+    expect(Halfword.fromBytes(file.content[18], file.content[19])).toEqual(
+      Halfword.fromUnsignedInteger(0x0011)
+    )
+    expect(Halfword.fromBytes(file.content[20], file.content[21])).toEqual(
       END_OF_CODE
+    )
+    expect(Halfword.fromBytes(file.content[22], file.content[23])).toEqual(
+      Halfword.fromUnsignedInteger(0x0000)
     )
   })
   it('should create data segment', function () {
@@ -131,10 +140,10 @@ describe('linker', function () {
     expect(file.segments.length).toBe(2)
     expect(file.segments[0].type).toBe(SegmentType.Load)
     expect(file.segments[0].offset).toBe(0)
-    expect(file.segments[0].size).toBe(14)
+    expect(file.segments[0].size).toBe(16)
     expect(file.segments[0].address).toEqual(Word.fromSignedInteger(0x08000000))
     expect(file.segments[1].type).toBe(SegmentType.Load)
-    expect(file.segments[1].offset).toBe(14)
+    expect(file.segments[1].offset).toBe(16)
     expect(file.segments[1].size).toBe(4)
     expect(file.segments[1].address).toEqual(Word.fromSignedInteger(0x20000000))
     expect(file.sections.length).toBe(0)
@@ -143,7 +152,7 @@ describe('linker', function () {
     expect(file.sourceMap.getLine(Word.fromSignedInteger(0x20000000))).toBe(0)
     expect(file.sourceMap.getLine(Word.fromSignedInteger(0x08000008))).toBe(1)
     expect(file.sourceMap.getLine(Word.fromSignedInteger(0x0800000a))).toBe(2)
-    expect(file.content.length).toBe(18)
+    expect(file.content.length).toBe(20)
     expect(
       Word.fromBytes(
         file.content[0],
@@ -169,7 +178,71 @@ describe('linker', function () {
     expect(Halfword.fromBytes(file.content[12], file.content[13])).toEqual(
       END_OF_CODE
     )
-    expect(file.content[14]).toEqual(Byte.fromUnsignedInteger(0x22))
+    expect(Halfword.fromBytes(file.content[14], file.content[15])).toEqual(
+      Halfword.fromUnsignedInteger(0x0000)
+    )
+    expect(file.content[16]).toEqual(Byte.fromUnsignedInteger(0x22))
+    expect(file.content[17]).toEqual(Byte.fromUnsignedInteger(0x00))
+    expect(file.content[18]).toEqual(Byte.fromUnsignedInteger(0x00))
+    expect(file.content[19]).toEqual(Byte.fromUnsignedInteger(0x00))
+  })
+  it('should align sections in segments', function () {
+    const code: ICodeFile = {
+      symbols: {},
+      areas: [
+        {
+          type: AreaType.Data,
+          isReadOnly: false,
+          name: '|.data_1|',
+          instructions: [
+            {
+              name: 'DCB',
+              options: ['0x22'],
+              line: 0
+            }
+          ]
+        },
+        {
+          type: AreaType.Data,
+          isReadOnly: false,
+          name: '|.data_2|',
+          instructions: [
+            {
+              name: 'DCW',
+              options: ['0x2222'],
+              line: 1
+            }
+          ]
+        },
+        {
+          type: AreaType.Code,
+          isReadOnly: true,
+          name: '|.text|',
+          instructions: [
+            {
+              name: 'MOVS',
+              options: ['R1', 'R1'],
+              line: 2
+            },
+            {
+              name: 'MOVS',
+              options: ['R2', 'R2'],
+              line: 3
+            }
+          ]
+        }
+      ]
+    }
+    const file = link(encode(code))
+    expect(file.segments.length).toBe(2)
+    expect(file.segments[0].type).toBe(SegmentType.Load)
+    expect(file.segments[0].offset).toBe(0)
+    expect(file.segments[0].size).toBe(16)
+    expect(file.segments[0].address).toEqual(Word.fromSignedInteger(0x08000000))
+    expect(file.segments[1].type).toBe(SegmentType.Load)
+    expect(file.segments[1].offset).toBe(16)
+    expect(file.segments[1].size).toBe(8)
+    expect(file.segments[1].address).toEqual(Word.fromSignedInteger(0x20000000))
   })
   it('should apply data relocations', function () {
     const code: ICodeFile = {
@@ -195,13 +268,13 @@ describe('linker', function () {
     expect(file.segments.length).toBe(1)
     expect(file.segments[0].type).toBe(SegmentType.Load)
     expect(file.segments[0].offset).toBe(0)
-    expect(file.segments[0].size).toBe(18)
+    expect(file.segments[0].size).toBe(20)
     expect(file.segments[0].address).toEqual(Word.fromSignedInteger(0x08000000))
     expect(file.sections.length).toBe(0)
     expect(Object.keys(file.symbols).length).toBe(0)
     expect(file.relocations.length).toBe(0)
     expect(file.sourceMap.getLine(Word.fromSignedInteger(0x08000008))).toBe(0)
-    expect(file.content.length).toBe(18)
+    expect(file.content.length).toBe(20)
     expect(
       Word.fromBytes(
         file.content[12],

--- a/test/assembler/linker.test.ts
+++ b/test/assembler/linker.test.ts
@@ -135,7 +135,7 @@ describe('linker', function () {
     expect(file.segments[0].address).toEqual(Word.fromSignedInteger(0x08000000))
     expect(file.segments[1].type).toBe(SegmentType.Load)
     expect(file.segments[1].offset).toBe(14)
-    expect(file.segments[1].size).toBe(1)
+    expect(file.segments[1].size).toBe(4)
     expect(file.segments[1].address).toEqual(Word.fromSignedInteger(0x20000000))
     expect(file.sections.length).toBe(0)
     expect(Object.keys(file.symbols).length).toBe(0)
@@ -143,7 +143,7 @@ describe('linker', function () {
     expect(file.sourceMap.getLine(Word.fromSignedInteger(0x20000000))).toBe(0)
     expect(file.sourceMap.getLine(Word.fromSignedInteger(0x08000008))).toBe(1)
     expect(file.sourceMap.getLine(Word.fromSignedInteger(0x0800000a))).toBe(2)
-    expect(file.content.length).toBe(15)
+    expect(file.content.length).toBe(18)
     expect(
       Word.fromBytes(
         file.content[0],


### PR DESCRIPTION
This PR fixes multiple issues with the alignment.

- The root problem was that `writer.getCurrentSectionOffset` was called before the alignment in `writer.writeBytes`. This caused the offset to be calculated wrongly (the alignment offset was ignored). To fix this issue the alignment is now added before the call to `writer.getCurrentSectionOffset`, so that all offsets are calculated correctly.
- As now all `writer.align` calls are explicit, the `alignment` parameter was removed from `writer.writeBytes`.
- There is now an alignment of sections in a segment, so that each section is word aligned in memory. This guarantees that everything which is aligned in a section, is also aligned within the segment and physical memory.
- To make the `END_OF_CODE` instruction work in all circumstances, there is now a `END_OF_CODE` directly after each section, so it's no longer possible to fall through a section into a next one. To go from one section to another, one must use jumps.
- `0x00` is used for alignment instead of `0xff`