### PR TITLE
VCB-205 allow spacing for instruction options

### DIFF
--- a/src/assembler/encoder.ts
+++ b/src/assembler/encoder.ts
@@ -113,18 +113,13 @@ function replaceEquConstants(
 ): void {
   for (let i = 0; i < instruction.options.length; i++) {
     const hasEndingBracket = instruction.options[i].endsWith(']')
-    if (
-      instruction.options[i].startsWith('#') &&
-      ((!hasEndingBracket && isNaN(+instruction.options[i].slice(1))) ||
-        (hasEndingBracket &&
-          isNaN(
-            +instruction.options[i].slice(1, instruction.options[i].length - 1)
-          )))
-    ) {
-      const equName = hasEndingBracket
-        ? instruction.options[i].slice(1, instruction.options[i].length - 1)
-        : instruction.options[i].slice(1)
-      const val = equConstants.get(equName)
+    let trimmedEquName = hasEndingBracket
+      ? instruction.options[i]
+          .slice(1, instruction.options[i].length - 1)
+          .trim()
+      : instruction.options[i].slice(1).trim()
+    if (instruction.options[i].startsWith('#') && isNaN(+trimmedEquName)) {
+      const val = equConstants.get(trimmedEquName)
 
       if (val && !hasEndingBracket) {
         instruction.options[i] = '#' + val.toUnsignedInteger().toString()
@@ -132,7 +127,7 @@ function replaceEquConstants(
         instruction.options[i] = '#' + val.toUnsignedInteger().toString() + ']'
       } else {
         throw new AssemblerError(
-          `Instruction refers to constant #${equName} which does not exists.`,
+          `Instruction refers to constant #${trimmedEquName} which does not exists.`,
           instruction.line
         )
       }
@@ -284,7 +279,7 @@ function writeDataInstruction(
     const bytes = Word.fromUnsignedInteger(0x0).toBytes()
     writer.align(4)
     for (const option of instruction.options) {
-      writer.addDataRelocation(option, bytes.length)
+      writer.addDataRelocation(option.trim(), bytes.length)
       writer.writeBytes(bytes)
     }
     return

--- a/src/assembler/parser/index.ts
+++ b/src/assembler/parser/index.ts
@@ -3,11 +3,11 @@ import { ParseError } from './error'
 import { ITextMatch, ITextParseRule, parseText } from './text'
 
 const SYMBOL = `[a-z_]+[a-z0-9_]*|\\|[a-z0-9._ ]+\\|`
-const VALUE = `[0-9a-z#]+`
+const VALUE = `[0-9a-z]+`
 const SPACE_OR_TAB = `[ \\t]`
 const STRING = `(?:"(?:[^'"\n]|'"?)*")`
 
-const OPTION = `(?:(?:[0-9a-z#=_]|[\\[{]${SPACE_OR_TAB}*|${SPACE_OR_TAB}*[\\]}]|${SPACE_OR_TAB}*-${SPACE_OR_TAB}*)+|${STRING})`
+const OPTION = `(?:(?:[0-9a-z_]|[\\[{#=]${SPACE_OR_TAB}*|${SPACE_OR_TAB}*[\\]}]|${SPACE_OR_TAB}*-${SPACE_OR_TAB}*)+|${STRING})`
 const INSTRUCTION = `([a-z]+)${SPACE_OR_TAB}+(${OPTION}(?:${SPACE_OR_TAB}*,${SPACE_OR_TAB}*${OPTION})*)`
 const LITERAL_SYMBOL_DECLARATION = `(${SYMBOL})${SPACE_OR_TAB}+EQU${SPACE_OR_TAB}+(${VALUE})`
 const AREA_DECLARATION = `AREA${SPACE_OR_TAB}+(${SYMBOL})${SPACE_OR_TAB}*,${SPACE_OR_TAB}*(DATA|CODE)${SPACE_OR_TAB}*,${SPACE_OR_TAB}*(READ(WRITE|ONLY))`

--- a/src/components/editor/plugins/assembly/assembly.grammar
+++ b/src/components/editor/plugins/assembly/assembly.grammar
@@ -164,11 +164,11 @@ kw<term> { @specialize[@name="Keyword"]<identifier, term> }
   }
 
   MachInstrIntegerLiteral {
-    "#" digits | ("=0x" | "=0X") hexDigits
+    "#" space* digits | ("=" space* "0x" | "=" space* "0X") hexDigits
   }
 
   MachInstrSymbolicLiteral {
-    "=" identifier
+    "=" space* identifier
   }
 
   IntegerLiteral {

--- a/src/instruction/instructions/load/ldr.ts
+++ b/src/instruction/instructions/load/ldr.ts
@@ -196,7 +196,7 @@ export class LdrRegisterInstruction extends BaseInstruction {
     if (instrHasLabelAsOffset) {
       let pseudoValue = options[1]
       if (pseudoValue.startsWith('=')) {
-        pseudoValue = pseudoValue.slice(1)
+        pseudoValue = pseudoValue.slice(1).trim()
       }
       immValue = createImmediateBits(
         //limit bit count so negative values will not be considered wrong

--- a/src/instruction/opcode.ts
+++ b/src/instruction/opcode.ts
@@ -196,7 +196,7 @@ export function createImmediateBits(
     )
   }
 
-  let optionValue = +option.substring(1)
+  let optionValue = +option.substring(1).trim()
   if (lsbZeroBitCount !== 0) {
     if (optionValue % (lsbZeroBitCount * 2) !== 0) {
       throw new InstructionError(

--- a/test/assembler/encoder.test.ts
+++ b/test/assembler/encoder.test.ts
@@ -463,4 +463,63 @@ describe('encode', function () {
     }
     expect(() => encode(code)).toThrow(AssemblerError)
   })
+  it('should encode code instruction with immediate offset with spaces in between', function () {
+    const code: ICodeFile = {
+      symbols: {
+        ['MY_CONST']: '0x0'
+      },
+      areas: [
+        {
+          type: AreaType.Code,
+          isReadOnly: true,
+          name: '|.code|',
+          instructions: [
+            {
+              name: 'STRB',
+              options: ['R1', '[R0', '#     MY_CONST]'],
+              line: 0
+            },
+            {
+              name: 'STRB',
+              options: ['R1', '[R0', '#     5]'],
+              line: 1
+            },
+            {
+              name: 'MOVS',
+              options: ['R0', '#     MY_CONST'],
+              line: 2
+            },
+            {
+              name: 'MOVS',
+              options: ['R0', '#     5'],
+              line: 3
+            },
+            {
+              name: 'LDR',
+              options: ['R0', '=       MY_CONST]'],
+              line: 4
+            },
+            {
+              name: 'LDR',
+              options: ['R0', '=     0x5]'],
+              line: 5
+            }
+          ]
+        }
+      ]
+    }
+    const file = encode(code)
+    expect(Object.keys(file.sections).length).toBe(1)
+    expect(getSection(file, '|.code|').offset).toBe(0)
+    expect(getSection(file, '|.code|').size).toBe(24)
+    expect(file.content.length).toBe(24)
+    expect(file.content[0].value).toBe(0x01)
+    expect(file.content[1].value).toBe(0x70)
+    expect(file.content[2].value).toBe(0x41)
+    expect(file.content[3].value).toBe(0x71)
+    expect(file.content[4].value).toBe(0x00)
+    expect(file.content[5].value).toBe(0x20)
+    expect(file.content[6].value).toBe(0x05)
+    expect(file.content[7].value).toBe(0x20)
+  })
 })

--- a/test/assembler/parser.test.ts
+++ b/test/assembler/parser.test.ts
@@ -182,6 +182,35 @@ AREA Pseudo, CODE, READONLY
     expect(ast.areas[1].instructions[3].options).toEqual(['R4', '=var2'])
     expect(ast.areas[1].instructions[3].line).toBe(14)
   })
+  it('can parse immediate offsets with spaces in between', () => {
+    const pseudoCode = `
+    AREA myCode, CODE, READWRITE
+    LDR R7, =   0x08123456f
+    start LDR R6, =  var1
+    LDR R0, =  ADDR_DIP_SWITCH_7_0
+    LDR R1, =	0x90000000
+    MOVS R2, #	44
+    `
+    const ast = parse(pseudoCode)
+    expect(ast.areas.length).toBe(1)
+    expect(ast.areas[0].instructions.length).toBe(5)
+
+    expect(ast.areas[0].instructions[0].name).toBe('LDR')
+    expect(ast.areas[0].instructions[0].options.length).toBe(2)
+
+    expect(ast.areas[0].instructions[1].name).toBe('LDR')
+    expect(ast.areas[0].instructions[1].label).toBeDefined()
+    expect(ast.areas[0].instructions[1].options.length).toBe(2)
+
+    expect(ast.areas[0].instructions[2].name).toBe('LDR')
+    expect(ast.areas[0].instructions[2].options.length).toBe(2)
+
+    expect(ast.areas[0].instructions[3].name).toBe('LDR')
+    expect(ast.areas[0].instructions[3].options.length).toBe(2)
+
+    expect(ast.areas[0].instructions[4].name).toBe('MOVS')
+    expect(ast.areas[0].instructions[4].options.length).toBe(2)
+  })
 })
 
 describe('parse text', function () {


### PR DESCRIPTION
```
;coment
ADDR_DIP_SWITCH_7_0         EQU     0x60000200
ADDR_DIP_SWITCH_15_8        EQU     0x60000201
	ADDR_DIP_SWITCH_31_24       EQU     0x60000203
ADDR_LED_7_0                EQU     0x60000100
ADDR_LED_15_8               EQU     0x60000101
   ADDR_LED_23_16              EQU     0x60000102
ADDR_LED_31_24              EQU     0x60000103
; ------------------------------------------------------------------
; -- Variables
; ------------------------------------------------------------------
        AREA MyAsmVar, DATA, READWRITE
; STUDENTS: To be programmed
var1 DCB 0xff
var DCD 0x12345678

; END: To be programmed
        ALIGN

; ------------------------------------------------------------------
; -- myCode
; ------------------------------------------------------------------
        AREA myCode, CODE, READONLY

main    PROC
        EXPORT main

readInput


	LDR R7, =   0x08123456f
start LDR R6, =  var1
 LDR R0, =  ADDR_DIP_SWITCH_7_0
 LDR R1, =	0x90000000
 MOVS R2, #	44
 LDR R3, =ADDR_DIP_SWITCH_31_24
 LDR R4, =ADDR_LED_23_16
 MOVS R5,  #  4

 B readInput

	
			 
		
		

```