### PR TITLE
VCB-241 Increase processor speed

### DIFF
--- a/src/board/processor.ts
+++ b/src/board/processor.ts
@@ -5,7 +5,8 @@ import { END_OF_CODE } from 'instruction/special'
 import { Word } from 'types/binary'
 import { EventEmitter } from 'types/events/emitter'
 
-const cycleSpeed: number = 10
+// We want the processor to cycle as fast as possible.
+const cycleSpeed: number = 0
 
 /**
  * The events which can be emitted by the processor.

--- a/src/board/processor.ts
+++ b/src/board/processor.ts
@@ -6,6 +6,8 @@ import { Word } from 'types/binary'
 import { EventEmitter } from 'types/events/emitter'
 
 // We want the processor to cycle as fast as possible.
+// A delay of `0` causes the JavaScript engine to execute the callback
+// at the next event loop cycle (immediately).
 const cycleSpeed: number = 0
 
 /**


### PR DESCRIPTION
Setting the `delay` of `setTimeout` to `0`, causes the browser to immediately invoke the callback at the next JavaScript event loop cycle.